### PR TITLE
Prevent accidental navigation from page

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       document.getElementById("iframework-info").innerHTML = "&raquo; 1/2: Loading libraries...";
 
       // Remember to debug with ?DEBUG
-      var debug = (window.location.search && window.location.search === "?DEBUG");
+      var debug = true;//(window.location.search && window.location.search === "?DEBUG");
 
       var anticache = "20130408";
 

--- a/src/iframework.js
+++ b/src/iframework.js
@@ -77,6 +77,14 @@ $(function(){
       // Hide panels
       this.closePanels();
 
+      window.addEventListener('popstate', function () {
+
+          if(window.location.href.match(/new/) && localStorage.preventSwipe) {
+            localStorage.removeItem('preventSwipe');
+          }
+
+        }, false);
+
       // After all of the .js is loaded, this.allLoaded will be triggered to finish the init
       this.once("allLoaded", this.loadLocalApps, this);
     },
@@ -315,6 +323,11 @@ $(function(){
       return gistid;
     },
     saveGist: function () {
+
+      if(localStorage.preventSwipe) {
+        localStorage.removeItem('preventSwipe');
+      }
+
       // Save app to gist
       var graph = this.shownGraph.toJSON();
       var data = {
@@ -420,6 +433,11 @@ $(function(){
       return key;
     },
     saveLocal: function () {
+
+      if(localStorage.preventSwipe) {
+        localStorage.removeItem('preventSwipe');
+      }
+
       if (!this.shownGraph.get("info")){
         this.shownGraph.set({
           info: {}

--- a/src/node-box-view.js
+++ b/src/node-box-view.js
@@ -146,6 +146,14 @@ $(function(){
       }
     },
     dragstop: function (event, ui) {
+
+      Iframework.router.navigate('/unsaved');
+
+      if(window.location.href.match(/unsaved/) && !localStorage.preventSwipe) {
+        localStorage.preventSwipe = true;
+        history.pushState(null, null, "#unsaved");
+      }
+
       // Redraw edges once more
       this.drag();
       // Save position to model


### PR DESCRIPTION
Finding out when the user swiped for back/forward proved too difficult (I even started a bounty of stackoverflow http://stackoverflow.com/questions/15829172/stop-chrome-back-forward-two-finger-swipe) 

My proposed fix:
I used the history API so that every time you move a component it switches to a "unsaved" state. Makes it really obvious that you have unfinished work. 
Also when this happens I push in the history the same URL. 
What happens is that if the user clicks back he remains on the page (!only if there is the "unsaved" hash in the URL). I also had to use localStorage to make sure I don't push the same url more than once making it impossible to go back.
If you save (both locally & on github) everything goes back to normal.

Let me know what you think. This pull req is just a proof of concept.

Sidenote: I  didn't understand how you used Grunt to build your scripts since you don't have an explicit Gruntfile so I forced the debug mode in index.html
